### PR TITLE
Improved inheritance of `scales::col_numeric` params

### DIFF
--- a/R/gt_hulk_color.R
+++ b/R/gt_hulk_color.R
@@ -1,20 +1,18 @@
 #' Apply 'hulk' palette to specific columns in a gt table.
 #' @description
-#' The hulk names comes from the idea of a diverging purple and green theme
+#' The hulk name comes from the idea of a diverging purple and green theme
 #' that is colorblind safe and visually appealing.
 #' It is a useful alternative to the red/green palette where purple typically
 #' can indicate low or "bad" value, and green can indicate a high or "good" value.
 #'
-#' @param gt_data An existing gt table object
-#' @param ... Additional arguments passed to scales::col_numeric
+#' @param gt_object An existing gt table object
+#' @param columns The columns wherein changes to cell data colors should occur.
 #' @param trim trim the palette to give less intense maximal colors
-#' @param na.color Applies to scales::col_numeric, the colour to return for NA values. Note that na.color = NA is valid.
-#' @param alpha Applies to scales:col_numeric, Whether alpha channels should be respected or ignored. If TRUE then colors without explicit alpha information will be treated as fully opaque.
-#' @param reverse Applied to scales::col_numeric, Whether the colors (or color function) in palette should be used in reverse order. The default order of this palette goes from purple to green, then reverse = TRUE will result in the colors going from green to purple.
+#' @inheritParams scales::col_numeric
+#' @inheritDotParams scales::col_numeric
 #' @return Returns a gt table
 #' @importFrom gt %>%
 #' @importFrom scales col_numeric
-#' @inheritParams scales::col_numeric
 #' @export
 #' @import gt
 #' @examples
@@ -48,22 +46,17 @@
 #' @family Colors
 #' @section Function ID:
 #' 2-1
-
-
-gt_hulk_color <- function(gt_object, columns = NULL, ..., trim = FALSE){
+gt_hulk_color <- function(gt_object, columns = NULL, domain = NULL, ..., trim = FALSE){
 
   pal_hex <- c("#762a83", "#af8dc3", "#e7d4e8", "#f7f7f7",
                "#d9f0d3", "#7fbf7b", "#1b7837")
 
-  pal_hex <- if(isTRUE(trim)){
-    pal_hex[2:6]
-  }else{
-    pal_hex
-  }
+  if(isTRUE(trim)) pal_hex <- pal_hex[2:6]
 
   hulk_pal <- function(x){
     scales::col_numeric(
       pal_hex,
+      domain = domain,
       ...
     )(x)
   }

--- a/man/gt_hulk_color.Rd
+++ b/man/gt_hulk_color.Rd
@@ -4,26 +4,47 @@
 \alias{gt_hulk_color}
 \title{Apply 'hulk' palette to specific columns in a gt table.}
 \usage{
-gt_hulk_color(gt_object, columns = NULL, ..., trim = FALSE)
+gt_hulk_color(gt_object, columns = NULL, domain = NULL, ..., trim = FALSE)
 }
 \arguments{
-\item{...}{Additional arguments passed to scales::col_numeric}
+\item{gt_object}{An existing gt table object}
+
+\item{columns}{The columns wherein changes to cell data colors should occur.}
+
+\item{domain}{The possible values that can be mapped.
+
+For \code{col_numeric} and \code{col_bin}, this can be a simple numeric
+range (e.g. \code{c(0, 100)}); \code{col_quantile} needs representative
+numeric data; and \code{col_factor} needs categorical data.
+
+If \code{NULL}, then whenever the resulting colour function is called, the
+\code{x} value will represent the domain. This implies that if the function
+is invoked multiple times, the encoding between values and colours may not
+be consistent; if consistency is needed, you must provide a non-\code{NULL}
+domain.}
+
+\item{...}{
+  Arguments passed on to \code{\link[scales:col_numeric]{scales::col_numeric}}
+  \describe{
+    \item{\code{palette}}{The colours or colour function that values will be mapped to}
+    \item{\code{na.color}}{The colour to return for \code{NA} values. Note that
+\code{na.color = NA} is valid.}
+    \item{\code{alpha}}{Whether alpha channels should be respected or ignored. If \code{TRUE}
+then colors without explicit alpha information will be treated as fully
+opaque.}
+    \item{\code{reverse}}{Whether the colors (or color function) in \code{palette} should be
+used in reverse order. For example, if the default order of a palette goes
+from blue to green, then \code{reverse = TRUE} will result in the colors going
+from green to blue.}
+  }}
 
 \item{trim}{trim the palette to give less intense maximal colors}
-
-\item{gt_data}{An existing gt table object}
-
-\item{na.color}{Applies to scales::col_numeric, the colour to return for NA values. Note that na.color = NA is valid.}
-
-\item{alpha}{Applies to scales:col_numeric, Whether alpha channels should be respected or ignored. If TRUE then colors without explicit alpha information will be treated as fully opaque.}
-
-\item{reverse}{Applied to scales::col_numeric, Whether the colors (or color function) in palette should be used in reverse order. The default order of this palette goes from purple to green, then reverse = TRUE will result in the colors going from green to purple.}
 }
 \value{
 Returns a gt table
 }
 \description{
-The hulk names comes from the idea of a diverging purple and green theme
+The hulk name comes from the idea of a diverging purple and green theme
 that is colorblind safe and visually appealing.
 It is a useful alternative to the red/green palette where purple typically
 can indicate low or "bad" value, and green can indicate a high or "good" value.


### PR DESCRIPTION
- Inherit dot params, 
- add domain explicitely since it has no default, 
- add column param, 
- fix gt_object param name
- simplify trim = TRUE code

NOTE: currently an `alpha` argument would be passed on to `scales::col_numeric` which describes the argument as 
```
Whether alpha channels should be respected or ignored. If TRUE then colors without explicit alpha information will be treated as fully opaque.
```
It would also be possible to pass an alpha argument to `gt::data_color` which describes the argument as 
```
An optional, fixed alpha transparency value that will be applied to all of the colors provided (regardless of whether a color palette was directly supplied or generated through a color mapping function).
```
I think you need to decide what your `alpha` should do.