### PR TITLE
Housekeeping Part 3:   ┬─┬ノ(ಠ_ಠノ)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,6 +41,6 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v1
         with:
-          extra-packages: rcmdcheck, rstudio/webshot2
+          extra-packages: rcmdcheck
 
       - uses: r-lib/actions/check-r-package@v1

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,6 +41,6 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v1
         with:
-          extra-packages: rcmdcheck
+          extra-packages: rcmdcheck, rstudio/webshot2
 
       - uses: r-lib/actions/check-r-package@v1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,61 +1,56 @@
-Package: gtExtras
 Type: Package
-Title: A Collection of Helper Functions for the gt Package
+Package: gtExtras
+Title: A Collection of Helper Functions for the 'gt' Package
 Version: 0.3
 Authors@R: c(
-    person(given = "Thomas", 
-           family = "Mock", 
-           email = "j.thomasmock@gmail.com", 
-           role = c("aut", "cre")),
-    person(given = "Daniel D.",
-             family = "Sjoberg",
-             role = c("ctb"),
-             email = "danield.sjoberg@gmail.com",
-             comment = c(ORCID = "0000-0003-0862-2018"))
-           )
-Author: Thomas Mock
-Maintainer: Thomas Mock <j.thomasmock@gmail.com>
-Description: Provides additional functions for creating beautiful tables with gt
+    person("Thomas", "Mock", , "j.thomasmock@gmail.com", role = c("aut", "cre", "cph")),
+    person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = "ctb",
+           comment = c(ORCID = "0000-0003-0862-2018"))
+  )
+Description: Provides additional functions for creating beautiful tables
+    with 'gt'. The functions are generally wrappers around boilerplate or
+    adding capabilities that are currently not built into 'gt'.
 License: MIT + file LICENSE
-Encoding: UTF-8
-LazyData: true
-RoxygenNote: 7.1.2
-Roxygen: list(markdown = TRUE)
 URL: https://github.com/jthomasmock/gtExtras,
-    https://jthomasmock.github.io/gtExtras
+    https://jthomasmock.github.io/gtExtras/
 BugReports: https://github.com/jthomasmock/gtExtras/issues
-Additional_repositories: https://jthomasmock.r-universe.dev
 Imports: 
-    dplyr (>= 0.8.5),
+    commonmark,
+    dplyr (>= 1.0.0),
+    fontawesome,
     ggplot2 (>= 3.3.0),
     glue (>= 1.3.2),
     gt (>= 0.3),
     htmltools (>= 0.5.0),
-    rlang (>= 0.4.5),
-    scales (>= 1.1.0),
     paletteer,
-    fontawesome,
-    commonmark
+    rlang (>= 0.4.5),
+    scales (>= 1.1.0)
 Suggests: 
     base64enc (>= 0.1-3),
-    fs (>= 1.3.2),
     bitops (>= 1.0.6),
     checkmate (>= 2.0.0),
+    covr,
+    fs (>= 1.3.2),
+    knitr,
     magrittr (>= 1.5),
     nflreadr,
+    RColorBrewer,
+    rmarkdown,
+    rvest,
     sass (>= 0.1.1),
     stringr (>= 1.3.1),
     svglite (>= 1.2.0.9001),
     testthat (>= 3.0.0),
     tibble (>= 3.0.0),
+    tidyr (>= 1.0.0),
     tidyselect (>= 1.0.0),
-    RColorBrewer,
-    rmarkdown,
-    rvest,
-    knitr,
-    tidyr,
-    covr,
     webshot2,
     xml2
-VignetteBuilder: knitr
+VignetteBuilder: 
+    knitr
+Additional_repositories: https://jthomasmock.r-universe.dev
 Config/testthat/edition: 3
+Encoding: UTF-8
+LazyData: true
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.1.2

--- a/README.Rmd
+++ b/README.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 # gtExtras
 
 <!-- badges: start -->
-[![Codecov test coverage](https://codecov.io/gh/jthomasmock/gtExtras/branch/master/graph/badge.svg)](https://codecov.io/gh/jthomasmock/gtExtras?branch=master)
+[![Codecov test coverage](https://codecov.io/gh/jthomasmock/gtExtras/branch/master/graph/badge.svg)](https://app.codecov.io/gh/jthomasmock/gtExtras?branch=master)
 [![R-CMD-check](https://github.com/jthomasmock/gtExtras/workflows/R-CMD-check/badge.svg)](https://github.com/jthomasmock/gtExtras/actions)
 <!-- badges: end -->
 
@@ -28,7 +28,7 @@ The functions are generally wrappers around boilerplate or adding capabilities t
 
 Full disclosure, `gtExtras` is under extremely active development. I appreciate any bug reports as issues, and I highly recommend updating frequently at least until an initial CRAN release.
 
-You can install the dev version of gtExtras from [GitHub](https://github.com/jthomasmock/gtExtra) with:
+You can install the dev version of gtExtras from [GitHub](https://github.com/jthomasmock/gtExtras) with:
 
 ``` r
 # if needed install.packages("remotes")

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <!-- badges: start -->
 
 [![Codecov test
-coverage](https://codecov.io/gh/jthomasmock/gtExtras/branch/master/graph/badge.svg)](https://codecov.io/gh/jthomasmock/gtExtras?branch=master)
+coverage](https://codecov.io/gh/jthomasmock/gtExtras/branch/master/graph/badge.svg)](https://app.codecov.io/gh/jthomasmock/gtExtras?branch=master)
 [![R-CMD-check](https://github.com/jthomasmock/gtExtras/workflows/R-CMD-check/badge.svg)](https://github.com/jthomasmock/gtExtras/actions)
 <!-- badges: end -->
 
@@ -25,7 +25,7 @@ appreciate any bug reports as issues, and I highly recommend updating
 frequently at least until an initial CRAN release.
 
 You can install the dev version of gtExtras from
-[GitHub](https://github.com/jthomasmock/gtExtra) with:
+[GitHub](https://github.com/jthomasmock/gtExtras) with:
 
 ``` r
 # if needed install.packages("remotes")

--- a/man/gtExtras-package.Rd
+++ b/man/gtExtras-package.Rd
@@ -4,20 +4,21 @@
 \name{gtExtras-package}
 \alias{gtExtras}
 \alias{gtExtras-package}
-\title{gtExtras: A Collection of Helper Functions for the gt Package}
+\title{gtExtras: A Collection of Helper Functions for the 'gt' Package}
 \description{
-Provides utility functions and common use-cases applied via the gt package.
+Provides additional functions for creating beautiful tables with 'gt'. The functions are generally wrappers around boilerplate or adding capabilities that are currently not built into 'gt'.
 }
 \seealso{
 Useful links:
 \itemize{
   \item \url{https://github.com/jthomasmock/gtExtras}
+  \item \url{https://jthomasmock.github.io/gtExtras/}
   \item Report bugs at \url{https://github.com/jthomasmock/gtExtras/issues}
 }
 
 }
 \author{
-\strong{Maintainer}: Thomas Mock \email{j.thomasmock@gmail.com}
+\strong{Maintainer}: Thomas Mock \email{j.thomasmock@gmail.com} [copyright holder]
 
 Other contributors:
 \itemize{


### PR DESCRIPTION
Hey hey! Oy, another one!

This PR focuses on items needed for CRAN acceptance, e.g. details stipulated in the Writing R Extensions Manual and in https://github.com/DavisVaughan/extrachecks. First submission of a pkg is tricky! But once it's been accepted, subsequent submissions are much easier.
- Since you're using the `Autho@Rs:` tag in `DESCRIPTION`, you don't need the Author and Maintainer fields.
- References to other packages, e.g. gt, must be quoted using single quotes. From Writing R Extensions Manual
    > The mandatory ‘Title’ field should give a short description of the package. Some package listings may truncate the title to 65 characters. It should use title case (that is, use capitals for the principal words: tools::toTitleCase can help you with this), not use any markup, not have any continuation lines, and not end in a period (unless part of …). Do not repeat the package name: it is often used prefixed by the name. Refer to other packages and external software in single quotes, and to book titles (and similar) in double quotes.
- I added a second sentence to the package description (lifted from what you had written in the README). CRAN requires at least two sentences.
- I bumped the minimum version requirement for tidyr and dplyr to 1.0.0 as both package had some breaking changes when they went to v1.0.0.
- I ran `usethis::use_tidy_description()`, which puts all the fields in the DESCRIPTION file in a standard order. It also puts the package dependencies in alphabetical order.
- I ran the URL checked and updated two URLs in the README.

Outstanding task: every exported function needs to be reviewed to ensure it has both an `@examples` and `@return` tag.