### PR TITLE
added text color arg for highlight rows and columns

### DIFF
--- a/R/gt_highlight_cols.R
+++ b/R/gt_highlight_cols.R
@@ -27,13 +27,13 @@
 #'
 
 gt_highlight_cols <- function(gt_object, columns, fill = "#80bcd8", alpha = 1,
-                              font_weight = "normal"){
+                              font_weight = "normal", font_color = '#000000'){
   stopifnot("Table must be of class 'gt_tbl'" = "gt_tbl" %in% class(gt_object))
     gt_object %>%
       tab_style(
         style = list(
           cell_fill(color = fill, alpha = alpha),
-          cell_text(weight = font_weight),
+          cell_text(weight = font_weight, color = font_color),
           cell_borders(sides = c("top", "bottom"), color = fill)
         ),
         locations = cells_body(

--- a/R/gt_highlight_rows.R
+++ b/R/gt_highlight_rows.R
@@ -42,7 +42,7 @@
 
 gt_highlight_rows <- function(
   gt_object, columns = gt::everything(), rows = TRUE, fill = "#80bcd8",
-  alpha = 0.8, font_weight = "bold", bold_target_only = FALSE, target_col = c()){
+  alpha = 0.8, font_weight = "bold", font_color = '#000000', bold_target_only = FALSE, target_col = c()){
 
   stopifnot("Table must be of class 'gt_tbl'" = "gt_tbl" %in% class(gt_object))
 
@@ -58,7 +58,7 @@ gt_highlight_rows <- function(
       ) %>%
       tab_style(
         style = list(
-          cell_text(weight = font_weight)
+          cell_text(weight = font_weight, color = font_color)
         ),
         locations = cells_body(
           columns = {{ target_col }},
@@ -70,7 +70,7 @@ gt_highlight_rows <- function(
       tab_style(
         style = list(
           cell_fill(color = fill, alpha = alpha),
-          cell_text(weight = font_weight)
+          cell_text(weight = font_weight, color = font_color)
         ),
         locations = cells_body(
           columns = {{ columns }},


### PR DESCRIPTION
Resolves #66 

Added an argument for changing the text color for `gt_highlight_rows` and `gt_highlight_cols`. Helps when needing to use a darker color for the fill // if wanting to use a non-black text font.