### PR TITLE
Fixes for gt v0.8.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,10 +17,10 @@ BugReports: https://github.com/jthomasmock/gtExtras/issues
 Imports: 
     commonmark,
     dplyr (>= 1.0.9),
-    fontawesome (>= 0.3.0),
-    ggplot2 (>= 3.3.6),
+    fontawesome (>= 0.4.0),
+    ggplot2 (>= 3.4.0),
     glue (>= 1.6.1),
-    gt (>= 0.7),
+    gt (>= 0.8.0),
     htmltools (>= 0.5.3),
     paletteer (>= 1.4.0),
     rlang (>= 1.0.4),

--- a/tests/testthat/test-fontawesome-icons.R
+++ b/tests/testthat/test-fontawesome-icons.R
@@ -16,11 +16,11 @@ test_that("fontawesome, test repeats", {
       rvest::html_attr("aria-label")
   }
 
-  expect_equal(row_counter(1), rep("Car", 5))
-  expect_equal(row_counter(2), rep("Car", 5))
-  expect_equal(row_counter(3), rep("Car", 3))
-  expect_equal(row_counter(4), rep("Car", 5))
-  expect_equal(row_counter(5), rep("Car", 7))
+  expect_equal(row_counter(1), rep("Car", 6))
+  expect_equal(row_counter(2), rep("Car", 6))
+  expect_equal(row_counter(3), rep("Car", 4))
+  expect_equal(row_counter(4), rep("Car", 6))
+  expect_equal(row_counter(5), rep("Car", 8))
   expect_equal(row_counter(6), character(0))
 
 })
@@ -115,10 +115,10 @@ test_that("fontawesome, test repeats", {
 
   pal_out <- c("red", "blue", "green")
 
-  pal_rep <- c(rep("red", 10), rep("blue", 3), rep("red", 5), rep("green", 7))
+  pal_rep <- c(rep("red", 12), rep("blue", 4), rep("red", 6), rep("green", 8))
 
-  expect_equal(color_fn("#FF0000"), rep("#FF0000", 25))
-  expect_equal(color_fn("blue"), rep("blue", 25))
+  expect_equal(color_fn("#FF0000"), rep("#FF0000", 30))
+  expect_equal(color_fn("blue"), rep("blue", 30))
   expect_equal(color_fn(pal_out), pal_rep)
 
 })

--- a/tests/testthat/test-gt_img_circle.R
+++ b/tests/testthat/test-gt_img_circle.R
@@ -28,6 +28,6 @@ test_that("svg is created and has specific values", {
       }) %>%
     unlist()
 
-  expect_true(all(test_style))
+  expect_equal(test_style, c(FALSE, TRUE, TRUE, TRUE, TRUE))
 
 })

--- a/tests/testthat/test-gt_index.R
+++ b/tests/testthat/test-gt_index.R
@@ -37,15 +37,18 @@ test_that("gt_index has correct inputs, correct ouput index, and can affect corr
     gt::as_raw_html() %>%
     rvest::read_html()
 
-  tab_styled <- tab_out_styled %>%
-    rvest::html_elements("td:nth-child(1)") %>%
-    .[c(2:4, 6:8, 10:12)] %>%
-    rvest::html_attr("style")
+  expect_equal(
+    tab_out_styled %>%
+      rvest::html_elements("td:nth-child(1)") %>%
+      as.character() %>%
+      grepl("background-color", .),
+    c(TRUE, FALSE, FALSE, FALSE, TRUE, TRUE, TRUE, TRUE, TRUE)
+  )
 
-  tab_pattern <- "background-color: \\s*(.*?)\\s*;"
-  reg_matches <- regmatches(tab_styled, regexec(tab_pattern, tab_styled)) %>%
-    lapply(function(x){x[2]}) %>%
-    unlist()
+  # tab_pattern <- "background-color: \\s*(.*?)\\s*;"
+  # reg_matches <- regmatches(tab_styled, regexec(tab_pattern, tab_styled)) %>%
+  #   lapply(function(x){x[2]}) %>%
+  #   unlist()
 
 #
 # # Expect color backgrounds to match ---------------------------------------

--- a/tests/testthat/test-gt_plt_conf_int.R
+++ b/tests/testthat/test-gt_plt_conf_int.R
@@ -34,7 +34,7 @@ test_that("gt_plt_conf_int generates correct points/text", {
     unlist() %>%
     unname()
 
-  expect_equal(ci_tab_style, rep("stroke-width: 1.06; stroke: #FFFFFF; fill: #000000;",3))
+  expect_equal(ci_tab_style, rep("stroke-linecap: round; stroke-linejoin: round; stroke-miterlimit: 10.00; stroke-width: 1.06; stroke: #FFFFFF; fill: #000000;",3))
 
   ci_tab_svg <- ci_tab_attrs %>%
     lapply(function(x){
@@ -80,7 +80,7 @@ test_that("gt_plt_conf_int uses correct points/text/colors", {
     unlist() %>%
     unname()
 
-  expect_equal(pre_tab_style, rep("stroke-width: 1.06; fill: #FF0000;",2))
+  expect_equal(pre_tab_style, rep("stroke: #000000; stroke-linecap: round; stroke-linejoin: round; stroke-miterlimit: 10.00; stroke-width: 1.06; fill: #FF0000;",2))
 
   pre_tab_svg <- pre_tab_attrs %>%
     lapply(function(x){

--- a/tests/testthat/test-gt_summary_table.R
+++ b/tests/testthat/test-gt_summary_table.R
@@ -45,7 +45,7 @@ test_that("table is created with expected output", {
     rvest::html_nodes("svg") %>%
     length()
 
-  expect_equal(ex_svg_len, 9)
+  expect_equal(ex_svg_len, 18)
 
 })
 


### PR DESCRIPTION
This fixes a few tests that are failing with the v0.8.0 release candidate for gt. That package has been submitted to CRAN but is not accepted yet. I'll let CRAN know that these fixes are available and a release of gtExtras will be forthcoming when gt is accepted. This also bumps the min version of a few package dependencies.