### PR TITLE
Two column layout with high level header

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: gtExtras
 Title: Extending 'gt' for Beautiful HTML Tables
-Version: 0.5.0.9004
+Version: 0.5.0.9005
 Authors@R: c(
     person("Thomas", "Mock", , "j.thomasmock@gmail.com", role = c("aut", "cre", "cph")),
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = "ctb",
@@ -48,6 +48,6 @@ Suggests:
     xml2 (>= 1.3.3)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Config/testthat/edition: 3
 Config/testthat/parallel: true

--- a/man/gt_two_column_layout.Rd
+++ b/man/gt_two_column_layout.Rd
@@ -13,7 +13,8 @@ gt_two_column_layout(
   vheight = 600,
   ...,
   zoom = 2,
-  expand = 5
+  expand = 5,
+  tab_header_from = NULL
 )
 }
 \arguments{
@@ -34,6 +35,8 @@ gt_two_column_layout(
 \item{zoom}{Argument to \code{webshot2::webshot()}. A number specifying the zoom factor. A zoom factor of 2 will result in twice as many pixels vertically and horizontally. Note that using 2 is not exactly the same as taking a screenshot on a HiDPI (Retina) device: it is like increasing the zoom to 200 doubling the height and width of the browser window. This differs from using a HiDPI device because some web pages load different, higher-resolution images when they know they will be displayed on a HiDPI device (but using zoom will not report that there is a HiDPI device).}
 
 \item{expand}{Argument to \code{webshot2::webshot()}. A numeric vector specifying how many pixels to expand the clipping rectangle by. If one number, the rectangle will be expanded by that many pixels on all sides. If four numbers, they specify the top, right, bottom, and left, in that order. When taking screenshots of multiple URLs, this parameter can also be a list with same length as url with each element of the list containing a single number or four numbers to use for the corresponding URL.}
+
+\item{tab_header_from}{If \code{NULL} (the default) renders tab headers of each table individually. If one of "table1" or "table2", the function extracts tab header information (including styling) from table 1 or table 2 respectively and renders it as high level header for the combined view (individual headers will be removed).}
 }
 \value{
 Saves a \code{.png} to disk if \code{output = "save"}, returns HTML to the viewer via \code{htmltools::browsable()} when \code{output = "viewer"}, or returns raw HTML if \code{output = "html"}.
@@ -133,8 +136,8 @@ Other Utilities:
 \code{\link{gt_img_multi_rows}()},
 \code{\link{gt_img_rows}()},
 \code{\link{gt_index}()},
-\code{\link{gt_merge_stack_color}()},
 \code{\link{gt_merge_stack}()},
+\code{\link{gt_merge_stack_color}()},
 \code{\link{gtsave_extra}()},
 \code{\link{img_header}()},
 \code{\link{pad_fn}()},


### PR DESCRIPTION
This is a more or less special feature I see people asking for in the nflverse discord. The main idea is to allow a high level tab header in the two column layout.
The problem here is formatting. We can either ask the user to set all the html styles themselves or try to help via gt. So in this PR, the function extracts tab header information (including all of the styling) from the header of one of the two tables. This allows the user to do all of the styling through gt. 

Example

```r

library(gt)
my_cars <- mtcars %>%
  dplyr::mutate(row_n = dplyr::row_number(), .before = mpg) %>%
  dplyr::select(row_n, mpg:drat)

tab1 <- my_cars %>%
  dplyr::slice(1:16) %>%
  gt() %>%
  gtExtras::gt_color_rows(columns = row_n, domain = 1:32) |> 
  gtExtras::gt_theme_538()

tab2 <- my_cars %>%
  dplyr::slice(17:32) %>%
  gt() %>%
  gtExtras::gt_color_rows(columns = row_n, domain = 1:32) |> 
  gt::tab_header(
    "A LONG AND VERY INFORMATIVE TITLE", "MY SUBTITLE IS ALSO VERY COOL"
  ) |> 
  gtExtras::gt_theme_538() |> 
  gt::tab_options(
    heading.background.color = "gray"
  )

listed_tables <- list(tab1, tab2)
```

## Current implementation
```r
gt_two_column_layout(
  listed_tables, output = "save",
  filename = "basic-two-col.png",
  vwidth = 700, vheight = 620
)
```
![basic-two-col](https://github.com/jthomasmock/gtExtras/assets/38586519/c9a4f91c-d90b-4c84-8d81-df643e4b1e85)


## With Header
```r
gt_two_column_layout(
  listed_tables, output = "save",
  filename = "basic-two-col-title.png",
  vwidth = 600, vheight = 620,
  tab_header_from = "table2"
)
```
![basic-two-col-title](https://github.com/jthomasmock/gtExtras/assets/38586519/3b99edff-d6e0-424c-8237-d11b78deca46)
