### PR TITLE
Fix missing theme column styling for stubhead.

### DIFF
--- a/R/gt_theme_538.R
+++ b/R/gt_theme_538.R
@@ -73,8 +73,9 @@ gt_theme_538 <- function(gt_object, ..., quiet = FALSE) {
           weight = 200
         )
       ),
-      locations = gt::cells_column_labels(
-        columns = gt::everything()
+      locations = list(
+        gt::cells_column_labels(),
+        gt::cells_stubhead()
       )
     ) %>%
     tab_style(

--- a/R/gt_theme_dark.R
+++ b/R/gt_theme_dark.R
@@ -47,7 +47,10 @@ gt_theme_dark <- function(gt_object, ...) {
         font = google_font("Source Sans Pro"),
         transform = "uppercase"
       ),
-      locations = cells_column_labels(everything())
+      locations = list(
+        cells_column_labels(),
+        cells_stubhead()
+      )
     ) %>%
     tab_style(
       style = cell_text(

--- a/R/gt_theme_nytimes.R
+++ b/R/gt_theme_nytimes.R
@@ -43,7 +43,10 @@ gt_theme_nytimes <- function(gt_object, ...) {
         font = google_font("Source Sans Pro"),
         transform = "uppercase"
       ),
-      locations = cells_column_labels(everything())
+      locations = list(
+        gt::cells_column_labels(),
+        gt::cells_stubhead()
+      )
     ) %>%
     tab_style(
       style = cell_text(

--- a/R/gt_theme_pff.R
+++ b/R/gt_theme_pff.R
@@ -157,6 +157,9 @@ gt_theme_pff <- function(gt_object, ..., divider, spanners, rank_col) {
           weight = px(2.5)
         )
       ),
-      locations = gt::cells_column_labels()
+      locations = list(
+        gt::cells_column_labels(),
+        gt::cells_stubhead()
+      )
     )
 }


### PR DESCRIPTION
Fixes #121 

Expands existing header cells styling to include an optional stubhead styling set by `tab_stubhead()` for four themes:
`gt_theme_538()`
`gt_theme_nytimes()`
`gt_theme_dark()`
`gt_theme_pff()`

