### PR TITLE
Adding "Identity Boxplot" to gt_plt_dist()

### DIFF
--- a/tests/testthat/test-gt_plt_dist.R
+++ b/tests/testthat/test-gt_plt_dist.R
@@ -7,6 +7,12 @@ test_that("svg is created", {
     dplyr::summarize(mpg_data = list(mpg), .groups = "drop") %>%
     gt()
 
+  fivenum_tab <- mtcars %>%
+    dplyr::group_by(cyl) %>%
+    # must end up with list of data for each row in the input dataframe
+    dplyr::summarize(mpg_data = list(stats::fivenum(mpg)), .groups = "drop") %>%
+    gt()
+
   get_svg_len <- function(table){
     table %>%
       gt::as_raw_html() %>%
@@ -46,6 +52,9 @@ test_that("svg is created", {
   gt_box <- base_tab %>%
     gt_plt_dist(mpg_data, type = "boxplot")
 
+  gt_box_manual <- fivenum_tab |>
+    gt_plt_dist(mpg_data, type = "boxplot_identity")
+
   expect_equal(get_svg_len(gt_dens), 3)
   expect_equal(get_svg_len(gt_dens_bw), 3)
   expect_equal(get_svg_len(gt_dens_lim), 3)
@@ -55,5 +64,6 @@ test_that("svg is created", {
   expect_equal(get_svg_len(gt_hist_bw), 3)
   expect_equal(get_svg_len(gt_hist_lim), 3)
   expect_equal(get_svg_len(gt_rug), 3)
+  expect_equal(get_svg_len(gt_box_manual), 3)
 
 })


### PR DESCRIPTION
## Rationale

I use R (or Python) for ETL and write simple summary statistics while processing the data. I recently wanted to visualize a five-num summary I wrote out for each dataset as a boxplot within a {gt} table, but found that {gtExtras} didn't allow this natively, since it's always assumed that the full set of data is present in the list col passed. In my case, it is not always possible to include the full dataset--nor advisable, due to size--but I'd still like to construct rudimentary boxplots in my table.

It seems like an easy addition, since {ggplot2} already allows this behavior natively (and {sparkline} does as well via `spk_chr(., type="box", raw=TRUE)`).

## Changes
- Adds an additional type to `gt_plt_dist()` called "boxplot_identity" that allows a user to pass variables to define boxplot via ggplot's `stat="identity"` option rather than raw data
- Updated unit tests
- Updated docs

## Example:

```r
mtcars |>
  dplyr::group_by(cyl) |>
  dplyr::summarize(mpg_data = list(stats::fivenum(mpg)), .groups = "drop") |>
  gt() |>
  gt_plt_dist(mpg_data, type = "boxplot_identity")
```

![image](https://github.com/user-attachments/assets/448fdbc9-be08-4eb1-b4e9-f185014902e0)


