### PR TITLE
fix error that did not allow missing rows with labels = T

### DIFF
--- a/R/gt-bar-html.R
+++ b/R/gt-bar-html.R
@@ -115,7 +115,7 @@ gt_plt_bar_pct <- function(
         # create label string to print out // add % sign if requested
         label <- glue::glue("{round(label_values, decimals)}%")
 
-        if (x < (label_cutoff * max_x)) {
+        if (!is.na(x) && x < (label_cutoff * max_x)) {
 
           css_styles <- paste0(
             "background:", fill,";",


### PR DESCRIPTION
Hi,

as I was playing around with these great functions for insetting bar plots into gt, I ran into an error every time I tried to use labels for the inset bar where I had some rows with missing values. I just moved a tiny check for missing x-values up the if-else chain, so that now it works as I suppose it was intended. 

All the best and thanks for the great package
Paul 