### PR TITLE
Addresses an Error message produced by {ggplot2} v3.5.2.9001

### DIFF
--- a/R/gt_plt_conf_int.R
+++ b/R/gt_plt_conf_int.R
@@ -232,7 +232,7 @@ add_ci_plot <- function(data_in,
       position = position_nudge(y = 0.25),
       family = "mono",
       fontface = "bold",
-      label.size = unit(0, "lines"),
+      linewidth = 0,
       label.padding = unit(0.05, "lines"),
       label.r = unit(0, "lines")
     ) +
@@ -246,7 +246,7 @@ add_ci_plot <- function(data_in,
       fill = "transparent",
       family = "mono",
       fontface = "bold",
-      label.size = unit(0, "lines"),
+      linewidth = 0,
       label.padding = unit(0.05, "lines"),
       label.r = unit(0, "lines")
     ) +


### PR DESCRIPTION
This PR addresses an issue logged in the base repo: https://github.com/jthomasmock/gtExtras/issues/149

Addresses an `Error` message produced by {ggplot2} v3.5.2.9001 cause by use of the deprecated `label.size` argument, replaced in this commit by `linewidth` which takes a numeric value (not a ggplot2::unit) in mm.