### PR TITLE
Add `font_size` argument to `gt_plt_sparkline()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,6 +48,6 @@ Suggests:
     lifecycle (>= 1.0.0)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Config/testthat/edition: 3
 Config/testthat/parallel: true

--- a/R/gt_plt_sparkline.R
+++ b/R/gt_plt_sparkline.R
@@ -11,6 +11,7 @@
 #' @param palette A character string with 5 elements indicating the colors of various components. Order matters, and palette = sparkline color, final value color, range color low, range color high, and 'type' color (eg shading or reference lines). To show a plot with no points (only the line itself), use: `palette = c("black", rep("transparent", 4))`.
 #' @param same_limit A logical indicating that the plots will use the same axis range (`TRUE`) or have individual axis ranges (`FALSE`).
 #' @param label A logical indicating whether the sparkline will have a numeric label for the last value in the vector, placed at the end of the plot.
+#' @param size A number indicating the font size of the numeric label when `label` is `TRUE`. Passed to [ggplot2::size].
 #' @return An object of class `gt_tbl`.
 #' @export
 #' @section Examples:
@@ -36,7 +37,8 @@ gt_plt_sparkline <- function(
   fig_dim = c(5, 30),
   palette = c("black", "black", "purple", "green", "lightgrey"),
   same_limit = TRUE,
-  label = TRUE
+  label = TRUE,
+  font_size = 2
 ) {
   stopifnot(
     "'gt_object' must be a 'gt_tbl', have you accidentally passed raw data?" = "gt_tbl" %in%
@@ -148,7 +150,7 @@ gt_plt_sparkline <- function(
               }
             )(.data$y)
           ),
-          size = 2,
+          size = font_size,
           family = "mono",
           hjust = 0,
           vjust = 0.5,
@@ -178,7 +180,7 @@ gt_plt_sparkline <- function(
               }
             )(.data$y)
           ),
-          size = 2,
+          size = font_size,
           family = "mono",
           hjust = 0,
           vjust = 0.5,

--- a/man/gt_plt_sparkline.Rd
+++ b/man/gt_plt_sparkline.Rd
@@ -11,7 +11,8 @@ gt_plt_sparkline(
   fig_dim = c(5, 30),
   palette = c("black", "black", "purple", "green", "lightgrey"),
   same_limit = TRUE,
-  label = TRUE
+  label = TRUE,
+  font_size = 2
 )
 }
 \arguments{
@@ -28,6 +29,8 @@ gt_plt_sparkline(
 \item{same_limit}{A logical indicating that the plots will use the same axis range (\code{TRUE}) or have individual axis ranges (\code{FALSE}).}
 
 \item{label}{A logical indicating whether the sparkline will have a numeric label for the last value in the vector, placed at the end of the plot.}
+
+\item{size}{A number indicating the font size of the numeric label when \code{label} is \code{TRUE}. Passed to \link[ggplot2:aes_linetype_size_shape]{ggplot2::size}.}
 }
 \value{
 An object of class \code{gt_tbl}.

--- a/tests/testthat/test-gt_plt_sparkline.R
+++ b/tests/testthat/test-gt_plt_sparkline.R
@@ -66,3 +66,68 @@ test_that("svg is created and has specific values", {
 
   expect_equal(spark_vals, "8.16,6.80 13.89,6.08 19.61,6.80 25")
 })
+
+test_that("font size can be changed", {
+  check_suggests()
+  
+  basic_gt <- mtcars %>%
+    dplyr::group_by(cyl) %>%
+    # must end up with list of data for each row in the input dataframe
+    dplyr::summarize(mpg_data = list(mpg), .groups = "drop") %>%
+    gt()
+  
+  # basic sparkline
+  gt_small_font <- basic_gt %>%
+    gt_plt_sparkline(mpg_data, label = TRUE)
+  gt_big_font <- basic_gt %>%
+    gt_plt_sparkline(mpg_data, label = TRUE, font_size = 10)
+  
+  get_html <- function(table) {
+    table %>%
+      gt::as_raw_html() %>%
+      rvest::read_html()
+  }
+  
+  small_font_html <- get_html(gt_small_font)
+  big_font_html <- get_html(gt_big_font)
+  
+  # SVG Exists and is of length 3 ----
+  
+  get_length <- function(html) {
+    html %>%
+      rvest::html_nodes("svg") %>%
+      length()
+  }
+  
+  expect_equal(get_length(small_font_html), get_length(big_font_html))
+  
+  # SVG has specific points ----
+  
+  small_font_spark_vals <- small_font_html %>%
+    rvest::html_node("polyline") %>%
+    rvest::html_attr("points") %>%
+    substr(1, 34)
+  
+  big_font_spark_vals <- big_font_html %>%
+    rvest::html_node("polyline") %>%
+    rvest::html_attr("points") %>%
+    substr(1, 34)
+  
+  expect_equal(small_font_spark_vals, big_font_spark_vals)
+  
+  # SVG has specific font size ----
+  
+  small_font_size <- small_font_html %>%
+    rvest::html_node("text") %>%
+    rvest::html_attr("style") %>%
+    stringr::str_extract("font-size: [0-9.]+px;")
+  
+  expect_equal(small_font_size, "font-size: 5.69px;")
+  
+  big_font_size <- big_font_html %>%
+    rvest::html_node("text") %>%
+    rvest::html_attr("style") %>%
+    stringr::str_extract("font-size: [0-9.]+px;")
+  
+  expect_equal(big_font_size, "font-size: 14.23px;")
+})


### PR DESCRIPTION
This PR adds a `font_size` argument to `gt_plt_sparkline()` to allow setting a custom font size for numeric labels. Closes #154.

```r
mtcars %>%
    dplyr::group_by(cyl) %>%
    dplyr::summarize(mpg_data = list(mpg), .groups = "drop") %>%
    gt() %>%
    gt_plt_sparkline(mpg_data, font_size = 2)
```
<img width="216" height="200" alt="Screenshot 2025-09-25 at 17 23 05" src="https://github.com/user-attachments/assets/d3f8f488-ec5f-42d2-b88d-1023099cf4ae" />

```r
mtcars %>%
    dplyr::group_by(cyl) %>%
    dplyr::summarize(mpg_data = list(mpg), .groups = "drop") %>%
    gt() %>%
    gt_plt_sparkline(mpg_data, font_size = 5)
```
<img width="216" height="200" alt="Screenshot 2025-09-25 at 17 23 58" src="https://github.com/user-attachments/assets/94e82789-2a7c-496e-93c6-7c50f17e8226" />
